### PR TITLE
REST controller

### DIFF
--- a/src/main/java/com/sst/utopia/booking/controller/BookingController.java
+++ b/src/main/java/com/sst/utopia/booking/controller/BookingController.java
@@ -81,4 +81,30 @@ public class BookingController {
 			return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
 		}
 	}
+
+	/**
+	 * Accept payment for a given reserved seat.
+	 * @param bookingId the ID code of the booking
+	 * @param payment the price the customer has paid for the ticket
+	 */
+	@PutMapping("/pay/{bookingId}")
+	public ResponseEntity<Ticket> acceptPaymentForBookingId(
+			@PathVariable final String bookingId,
+			@RequestBody final PaymentAmount payment) {
+		try {
+			return new ResponseEntity<>(
+					service.acceptPayment(bookingId, payment.getPrice()),
+					HttpStatus.OK);
+		} catch (final IllegalArgumentException except) {
+			return new ResponseEntity<>(HttpStatus.GONE);
+		} catch (final IllegalStateException except) {
+			if (except.getMessage().contains("Uniqueness")) {
+				return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+			} else {
+				return new ResponseEntity<>(HttpStatus.CONFLICT);
+			}
+		} catch (final Exception except) {
+			return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+		}
+	}
 }

--- a/src/main/java/com/sst/utopia/booking/controller/BookingController.java
+++ b/src/main/java/com/sst/utopia/booking/controller/BookingController.java
@@ -150,4 +150,54 @@ public class BookingController {
 			return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
 		}
 	}
+
+	/**
+	 * Extend the reservation timeout for the given unpaid booking. TODO: limit the
+	 * number of times this is allowed
+	 *
+	 * @param flight the flight number of the flight
+	 * @param row    the row number of the seat
+	 * @param seat   the seat within the row
+	 */
+	@PutMapping("/extend/flights/{flight}/rows/{row}/seats/{seat}")
+	public ResponseEntity<Object> extendTimeout(@PathVariable final int flight,
+			@PathVariable final int row, @PathVariable final String seat) {
+		try {
+			service.extendReservationTimeout(service.getTicket(
+					new SeatLocation(service.getFlight(flight), row, seat)));
+			return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+		} catch (final NoSuchElementException except) {
+			return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+		} catch (final IllegalArgumentException except) {
+			return new ResponseEntity<>(HttpStatus.GONE);
+		} catch (final IllegalStateException except) {
+			return new ResponseEntity<>(HttpStatus.CONFLICT);
+		} catch (final Exception except) {
+			return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+		}
+	}
+
+	/**
+	 * Extend the reservation timeout for the given unpaid booking. TODO: limit the
+	 * number of times this is allowed
+	 *
+	 * @param bookingId the booking-ID for the seat
+	 */
+	@PutMapping("/extend/bookings/{bookingId}")
+	public ResponseEntity<Object> extendTimeout(@PathVariable final String bookingId) {
+		try {
+			service.extendReservationTimeout(bookingId);
+			return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+		} catch (final IllegalArgumentException except) {
+			return new ResponseEntity<>(HttpStatus.GONE);
+		} catch (final IllegalStateException except) {
+			if (except.getMessage().contains("Uniqueness")) {
+				return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+			} else {
+				return new ResponseEntity<>(HttpStatus.CONFLICT);
+			}
+		} catch (final Exception except) {
+			return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+		}
+	}
 }

--- a/src/main/java/com/sst/utopia/booking/controller/BookingController.java
+++ b/src/main/java/com/sst/utopia/booking/controller/BookingController.java
@@ -205,9 +205,9 @@ public class BookingController {
 	/**
 	 * Get the details of a ticket.
 	 *
-	 * @param flight the flight number of the flight
+	 * @param flightId the flight number of the flight
 	 * @param row    the row number of the seat
-	 * @param seat   the seat within the row
+	 * @param seatId   the seat within the row
 	 */
 	@GetMapping("/details/flights/{flightId}/rows/{row}/seats/{seatId}")
 	public ResponseEntity<Ticket> getBookingDetails(@PathVariable final int flightId,

--- a/src/main/java/com/sst/utopia/booking/controller/BookingController.java
+++ b/src/main/java/com/sst/utopia/booking/controller/BookingController.java
@@ -1,0 +1,53 @@
+package com.sst.utopia.booking.controller;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import com.sst.utopia.booking.model.SeatLocation;
+import com.sst.utopia.booking.model.Ticket;
+import com.sst.utopia.booking.model.User;
+import com.sst.utopia.booking.service.BookingService;
+
+/**
+ * Controller to present the booking service to the microservices that provide
+ * the client-facing API.
+ *
+ * @author Jonathan Lovelace
+ */
+@RestController
+@RequestMapping("/booking")
+public class BookingController {
+	/**
+	 * Service class used to handle requests.
+	 */
+	@Autowired
+	private BookingService service;
+	/**
+	 * Reserve a ticket for the given seat.
+	 * FIXME: Allow getting the user from headers (injected by the security layer)
+	 * @param flight the flight number of the flight
+	 * @param row the row number of the seat
+	 * @param seat the seat within the row
+	 * @param user the user details
+	 */
+	@PostMapping("/book/{flight}/{row}/{seat}")
+	public ResponseEntity<Ticket> bookTicket(@PathVariable final int flight,
+			@PathVariable final int row, @PathVariable final String seat,
+			@RequestBody final User user) {
+		try {
+			return new ResponseEntity<>(service.bookTicket(
+					new SeatLocation(service.getFlight(flight), row, seat), user),
+					HttpStatus.CREATED);
+		} catch (final IllegalArgumentException except) {
+			return new ResponseEntity<>(HttpStatus.CONFLICT);
+		} catch (final Exception except) {
+			return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+		}
+	}
+}

--- a/src/main/java/com/sst/utopia/booking/controller/BookingController.java
+++ b/src/main/java/com/sst/utopia/booking/controller/BookingController.java
@@ -41,7 +41,7 @@ public class BookingController {
 	 * @param seat the seat within the row
 	 * @param user the user details
 	 */
-	@PostMapping("/book/{flight}/{row}/{seat}")
+	@PostMapping("/book/flights/{flight}/rows/{row}/seats/{seat}")
 	public ResponseEntity<Ticket> bookTicket(@PathVariable final int flight,
 			@PathVariable final int row, @PathVariable final String seat,
 			@RequestBody final User user) {
@@ -62,7 +62,7 @@ public class BookingController {
 	 * @param seat the seat within the row
 	 * @param payment the price the customer has paid for the ticket
 	 */
-	@PutMapping("/pay/{flight}/{row}/{seat}")
+	@PutMapping("/pay/flights/{flight}/rows/{row}/seats/{seat}")
 	public ResponseEntity<Ticket> acceptPayment(@PathVariable final int flight,
 			@PathVariable final int row, @PathVariable final String seat,
 			@RequestBody final PaymentAmount payment) {
@@ -88,7 +88,7 @@ public class BookingController {
 	 * @param bookingId the ID code of the booking
 	 * @param payment the price the customer has paid for the ticket
 	 */
-	@PutMapping("/pay/{bookingId}")
+	@PutMapping("/pay/bookings/{bookingId}")
 	public ResponseEntity<Ticket> acceptPaymentForBookingId(
 			@PathVariable final String bookingId,
 			@RequestBody final PaymentAmount payment) {
@@ -116,7 +116,7 @@ public class BookingController {
 	 * @param row    the row number of the seat
 	 * @param seat   the seat within the row
 	 */
-	@DeleteMapping("/book/{flight}/{row}/{seat}")
+	@DeleteMapping("/book/flights/{flight}/rows/{row}/seats/{seat}")
 	public ResponseEntity<Object> cancelReservation(@PathVariable final int flight,
 			@PathVariable final int row, @PathVariable final String seat) {
 		try {
@@ -138,7 +138,7 @@ public class BookingController {
 	 *
 	 * @param bookingId the booking-ID for the seat
 	 */
-	@DeleteMapping("/book/{bookingId}")
+	@DeleteMapping("/book/bookings/{bookingId}")
 	public ResponseEntity<Object> cancelBookingById(
 			@PathVariable final String bookingId) {
 		try {

--- a/src/main/java/com/sst/utopia/booking/controller/BookingController.java
+++ b/src/main/java/com/sst/utopia/booking/controller/BookingController.java
@@ -6,6 +6,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
+import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -196,6 +197,27 @@ public class BookingController {
 			} else {
 				return new ResponseEntity<>(HttpStatus.CONFLICT);
 			}
+		} catch (final Exception except) {
+			return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+		}
+	}
+
+	/**
+	 * Get the details of a ticket.
+	 *
+	 * @param flight the flight number of the flight
+	 * @param row    the row number of the seat
+	 * @param seat   the seat within the row
+	 */
+	@GetMapping("/details/flights/{flightId}/rows/{row}/seats/{seatId}")
+	public ResponseEntity<Ticket> getBookingDetails(@PathVariable final int flightId,
+			@PathVariable final int row, @PathVariable final String seatId) {
+		try {
+			return new ResponseEntity<>(service.getTicket(
+					new SeatLocation(service.getFlight(flightId), row, seatId)),
+					HttpStatus.OK);
+		} catch (final NoSuchElementException except) {
+			return new ResponseEntity<>(HttpStatus.NOT_FOUND);
 		} catch (final Exception except) {
 			return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
 		}

--- a/src/main/java/com/sst/utopia/booking/controller/BookingController.java
+++ b/src/main/java/com/sst/utopia/booking/controller/BookingController.java
@@ -5,6 +5,7 @@ import java.util.NoSuchElementException;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.PutMapping;
@@ -103,6 +104,48 @@ public class BookingController {
 			} else {
 				return new ResponseEntity<>(HttpStatus.CONFLICT);
 			}
+		} catch (final Exception except) {
+			return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+		}
+	}
+	/**
+	 * Cancel unpaid reservation for a given seat. TODO: Only the ticket-holder
+	 * should be able to cancel it
+	 *
+	 * @param flight the flight number of the flight
+	 * @param row    the row number of the seat
+	 * @param seat   the seat within the row
+	 */
+	@DeleteMapping("/book/{flight}/{row}/{seat}")
+	public ResponseEntity<Object> cancelReservation(@PathVariable final int flight,
+			@PathVariable final int row, @PathVariable final String seat) {
+		try {
+			service.cancelPendingReservation(service.getTicket(
+					new SeatLocation(service.getFlight(flight), row, seat)));
+			return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+		} catch (final NoSuchElementException except) {
+			return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+		} catch (final IllegalArgumentException except) {
+			return new ResponseEntity<>(HttpStatus.CONFLICT);
+		} catch (final Exception except) {
+			return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+		}
+	}
+
+	/**
+	 * Cancel unpaid reservation for a given booking-ID. TODO: only the ticket
+	 * holder should be able to cancel it
+	 *
+	 * @param bookingId the booking-ID for the seat
+	 */
+	@DeleteMapping("/book/{bookingId}")
+	public ResponseEntity<Object> cancelBookingById(
+			@PathVariable final String bookingId) {
+		try {
+			service.cancelPendingReservation(bookingId);
+			return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+		} catch (final IllegalArgumentException except) {
+			return new ResponseEntity<>(HttpStatus.CONFLICT);
 		} catch (final Exception except) {
 			return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
 		}

--- a/src/main/java/com/sst/utopia/booking/controller/BookingController.java
+++ b/src/main/java/com/sst/utopia/booking/controller/BookingController.java
@@ -71,6 +71,8 @@ public class BookingController {
 							new SeatLocation(service.getFlight(flight), row, seat)),
 					payment.getPrice());
 			return new ResponseEntity<>(HttpStatus.OK);
+		} catch (final IllegalStateException except) {
+			return new ResponseEntity<>(HttpStatus.CONFLICT);
 		} catch (final IllegalArgumentException except) {
 			return new ResponseEntity<>(HttpStatus.GONE);
 		} catch (final NoSuchElementException except) {

--- a/src/main/java/com/sst/utopia/booking/controller/BookingController.java
+++ b/src/main/java/com/sst/utopia/booking/controller/BookingController.java
@@ -1,14 +1,18 @@
 package com.sst.utopia.booking.controller;
 
+import java.util.NoSuchElementException;
+
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.PutMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
+import com.sst.utopia.booking.model.PaymentAmount;
 import com.sst.utopia.booking.model.SeatLocation;
 import com.sst.utopia.booking.model.Ticket;
 import com.sst.utopia.booking.model.User;
@@ -46,6 +50,31 @@ public class BookingController {
 					HttpStatus.CREATED);
 		} catch (final IllegalArgumentException except) {
 			return new ResponseEntity<>(HttpStatus.CONFLICT);
+		} catch (final Exception except) {
+			return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
+		}
+	}
+	/**
+	 * Accept payment for a given reserved seat.
+	 * @param flight the flight number of the flight
+	 * @param row the row number of the seat
+	 * @param seat the seat within the row
+	 * @param payment the price the customer has paid for the ticket
+	 */
+	@PutMapping("/pay/{flight}/{row}/{seat}")
+	public ResponseEntity<Ticket> acceptPayment(@PathVariable final int flight,
+			@PathVariable final int row, @PathVariable final String seat,
+			@RequestBody final PaymentAmount payment) {
+		try {
+			service.acceptPayment(
+					service.getTicket(
+							new SeatLocation(service.getFlight(flight), row, seat)),
+					payment.getPrice());
+			return new ResponseEntity<>(HttpStatus.OK);
+		} catch (final IllegalArgumentException except) {
+			return new ResponseEntity<>(HttpStatus.GONE);
+		} catch (final NoSuchElementException except) {
+			return new ResponseEntity<>(HttpStatus.NOT_FOUND);
 		} catch (final Exception except) {
 			return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
 		}

--- a/src/main/java/com/sst/utopia/booking/model/PaymentAmount.java
+++ b/src/main/java/com/sst/utopia/booking/model/PaymentAmount.java
@@ -1,0 +1,20 @@
+package com.sst.utopia.booking.model;
+
+/**
+ * A simple wrapper around a single integer representing an amount paid for a
+ * ticket.
+ *
+ * @author Jonathan Lovelace
+ */
+public class PaymentAmount {
+	/**
+	 * The amount paid.
+	 */
+	private int price;
+	/**
+	 * @return the amount paid
+	 */
+	public int getPrice() {
+		return price;
+	}
+}

--- a/src/main/java/com/sst/utopia/booking/model/Ticket.java
+++ b/src/main/java/com/sst/utopia/booking/model/Ticket.java
@@ -9,6 +9,10 @@ import javax.persistence.JoinColumn;
 import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 
+import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.annotation.JsonProperty.Access;
+
 /**
  * A ticket, or seat (for which a ticket may be or may have been sold), on a
  * flight.
@@ -44,6 +48,7 @@ public class Ticket {
 	 */
 	@ManyToOne
 	@JoinColumn(nullable = true, name="reserver")
+	@JsonProperty(access = Access.WRITE_ONLY)
 	private User reserver;
 	/**
 	 * The price that the ticket-holder paid to book this seat; must be null if
@@ -203,5 +208,12 @@ public class Ticket {
 		} else {
 			return reservationTimeout == null;
 		}
+	}
+	/**
+	 * @return whether the ticket has been booked
+	 */
+	@JsonGetter(value = "reserved")
+	public boolean isReserved() {
+		return reserver != null;
 	}
 }

--- a/src/main/java/com/sst/utopia/booking/service/BookingService.java
+++ b/src/main/java/com/sst/utopia/booking/service/BookingService.java
@@ -45,7 +45,7 @@ public class BookingService {
 	private int defaultBookingExpiration;
 
 	/**
-	 * Get a specified
+	 * Get a specified flight by its flight number.
 	 * @param flightNumber the flight-number of a flight
 	 * @return the flight with that number, or null if there
 	 */
@@ -56,6 +56,16 @@ public class BookingService {
 		} else {
 			return list.get(0);
 		}
+	}
+
+	/**
+	 * Get a specified ticket by its flight and seat location.
+	 * @param seat the flight and seat location desired
+	 * @return the ticket, booked or not, for that seat
+	 * @throws NoSuchElementException if no such seat in the database
+	 */
+	public Ticket getTicket(final SeatLocation seat) {
+		return ticketDao.findById(seat).get();
 	}
 
 	/**
@@ -113,7 +123,7 @@ public class BookingService {
 	 * @param price  the price the ticket-holder paid
 	 * @return the updated booking information
 	 * @throws IllegalArgumentException if ticket is not booked or has already been
-	 *                                  paid for
+	 *                                  paid for TODO: split these conditions
 	 */
 	@Transactional
 	public Ticket acceptPayment(final Ticket ticket, final int price) {

--- a/src/main/java/com/sst/utopia/booking/service/BookingService.java
+++ b/src/main/java/com/sst/utopia/booking/service/BookingService.java
@@ -106,11 +106,11 @@ public class BookingService {
 		}
 		ticket.setReserver(user);
 		ticket.setReservationTimeout(timeout);
-		ticket.setBookingId(DigestUtils.md5DigestAsHex(new StringBuilder()
-				.append(Integer.toString(seat.getFlight().getFlightNumber()))
-				.append(' ').append(Integer.toString(seat.getRow())).append(' ')
-				.append(seat.getSeat()).append(' ')
-				.append(Integer.toString(user.getId())).toString().getBytes()));
+		ticket.setBookingId(
+				DigestUtils.md5DigestAsHex(String
+						.format("%d %d %s %d", seat.getFlight().getFlightNumber(),
+								seat.getRow(), seat.getSeat(), user.getId())
+						.getBytes()));
 		ticketDao.saveAndFlush(ticket);
 		return ticket;
 	}

--- a/src/test/java/com/sst/utopia/booking/controller/BookingControllerTest.java
+++ b/src/test/java/com/sst/utopia/booking/controller/BookingControllerTest.java
@@ -4,6 +4,7 @@ import static org.hamcrest.CoreMatchers.is;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -208,5 +209,19 @@ class BookingControllerTest {
 				.contentType(MediaType.APPLICATION_JSON).content("{\"price\":300}"));
 		mvc.perform(put("/booking/extend/bookings/" + bookingId))
 				.andExpect(status().isConflict());
+	}
+
+	@Test
+	public void testGetBookingDetails() throws Exception {
+		mvc.perform(get("/booking/details/flights/154/rows/1/seats/A"))
+				.andExpect(status().isNotFound());
+		mvc.perform(get("/booking/details/flights/152/rows/1/seats/A"))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.reserved", is(false)));
+		mvc.perform(post("/booking/book/flights/152/rows/1/seats/A/")
+				.contentType(MediaType.APPLICATION_JSON).content("{\"id\":1}"));
+		mvc.perform(get("/booking/details/flights/152/rows/1/seats/A"))
+				.andExpect(status().isOk())
+				.andExpect(jsonPath("$.reserved", is(true)));
 	}
 }

--- a/src/test/java/com/sst/utopia/booking/controller/BookingControllerTest.java
+++ b/src/test/java/com/sst/utopia/booking/controller/BookingControllerTest.java
@@ -89,28 +89,28 @@ class BookingControllerTest {
 
 	@Test
 	public void testBookTicket() throws Exception {
-		mvc.perform(post("/booking/book/152/1/A/")
+		mvc.perform(post("/booking/book/flights/152/rows/1/seats/A/")
 				.contentType(MediaType.APPLICATION_JSON).content("{\"id\": 1}"))
 				.andExpect(status().isCreated());
-		mvc.perform(post("/booking/book/152/1/A/")
+		mvc.perform(post("/booking/book/flights/152/rows/1/seats/A/")
 				.contentType(MediaType.APPLICATION_JSON).content("{\"id\": 2}"))
 				.andExpect(status().isConflict());
 	}
 
 	@Test
 	public void testAcceptPayment() throws Exception {
-		mvc.perform(put("/booking/pay/152/1/A")
+		mvc.perform(put("/booking/pay/flights/152/rows/1/seats/A")
 				.contentType(MediaType.APPLICATION_JSON).content("{\"price\":300}"))
 				.andExpect(status().isGone());
-		mvc.perform(post("/booking/book/152/1/A/")
+		mvc.perform(post("/booking/book/flights/152/rows/1/seats/A/")
 				.contentType(MediaType.APPLICATION_JSON).content("{\"id\":1}"));
-		mvc.perform(put("/booking/pay/152/1/A")
+		mvc.perform(put("/booking/pay/flights/152/rows/1/seats/A")
 				.contentType(MediaType.APPLICATION_JSON).content("{\"price\":300}"))
 				.andExpect(status().isOk());
-		mvc.perform(put("/booking/pay/152/1/A")
+		mvc.perform(put("/booking/pay/flights/152/rows/1/seats/A")
 				.contentType(MediaType.APPLICATION_JSON).content("{\"price\":300}"))
 				.andExpect(status().isOk()); // testing idempotency
-		mvc.perform(put("/booking/pay/152/1/A")
+		mvc.perform(put("/booking/pay/flights/152/rows/1/seats/A")
 				.contentType(MediaType.APPLICATION_JSON).content("{\"price\":400}"))
 				.andExpect(status().isConflict());
 	}
@@ -118,19 +118,19 @@ class BookingControllerTest {
 	@Test
 	public void testAcceptPaymentByBookingId() throws Exception {
 		final String bookingId = DigestUtils.md5DigestAsHex("152 1 A 1".getBytes());
-		mvc.perform(put("/booking/pay/" + bookingId)
+		mvc.perform(put("/booking/pay/bookings/" + bookingId)
 				.contentType(MediaType.APPLICATION_JSON).content("{\"price\":300}"))
 				.andExpect(status().isGone());
-		mvc.perform(post("/booking/book/152/1/A/")
+		mvc.perform(post("/booking/book/flights/152/rows/1/seats/A/")
 				.contentType(MediaType.APPLICATION_JSON).content("{\"id\":1}"))
 				.andExpect(jsonPath("$.bookingId", is(bookingId)));
-		mvc.perform(put("/booking/pay/" + bookingId)
+		mvc.perform(put("/booking/pay/bookings/" + bookingId)
 				.contentType(MediaType.APPLICATION_JSON).content("{\"price\":300}"))
 				.andExpect(status().isOk());
-		mvc.perform(put("/booking/pay/" + bookingId)
+		mvc.perform(put("/booking/pay/bookings/" + bookingId)
 				.contentType(MediaType.APPLICATION_JSON).content("{\"price\":300}"))
 				.andExpect(status().isOk()); // testing idempotency
-		mvc.perform(put("/booking/pay/" + bookingId)
+		mvc.perform(put("/booking/pay/bookings/" + bookingId)
 				.contentType(MediaType.APPLICATION_JSON).content("{\"price\":400}"))
 				.andExpect(status().isConflict());
 	}
@@ -138,36 +138,36 @@ class BookingControllerTest {
 	@Test
 	public void testCancelReservation() throws Exception {
 		final SeatLocation seat = new SeatLocation(flightDao.findByFlightNumber(152).get(0), 1, "A");
-		mvc.perform(delete("/booking/book/152/1/A")).andExpect(status().isNoContent());
-		mvc.perform(post("/booking/book/152/1/A/")
+		mvc.perform(delete("/booking/book/flights/152/rows/1/seats/A")).andExpect(status().isNoContent());
+		mvc.perform(post("/booking/book/flights/152/rows/1/seats/A/")
 				.contentType(MediaType.APPLICATION_JSON).content("{\"id\": 1}"));
 		assertTrue(ticketDao.findById(seat).map(Ticket::getReserver).isPresent());
-		mvc.perform(delete("/booking/book/152/1/A")).andExpect(status().isNoContent());
+		mvc.perform(delete("/booking/book/flights/152/rows/1/seats/A")).andExpect(status().isNoContent());
 		assertFalse(ticketDao.findById(seat).map(Ticket::getReserver).isPresent());
-		mvc.perform(delete("/booking/book/235/4/D")).andExpect(status().isNotFound());
-		mvc.perform(post("/booking/book/152/1/A/")
+		mvc.perform(delete("/booking/book/flights/235/rows/4/seats/D")).andExpect(status().isNotFound());
+		mvc.perform(post("/booking/book/flights/152/rows/1/seats/A/")
 				.contentType(MediaType.APPLICATION_JSON).content("{\"id\": 1}"));
-		mvc.perform(put("/booking/pay/152/1/A")
+		mvc.perform(put("/booking/pay/flights/152/rows/1/seats/A")
 				.contentType(MediaType.APPLICATION_JSON).content("{\"price\":300}"));
-		mvc.perform(delete("/booking/book/152/1/A")).andExpect(status().isConflict());
+		mvc.perform(delete("/booking/book/flights/152/rows/1/seats/A")).andExpect(status().isConflict());
 	}
 
 	@Test
 	public void testCancelByBookingId() throws Exception {
 		final String bookingId = DigestUtils.md5DigestAsHex("152 1 A 1".getBytes());
-		mvc.perform(delete("/booking/book/" + bookingId))
+		mvc.perform(delete("/booking/book/bookings/" + bookingId))
 				.andExpect(status().isNoContent());
-		mvc.perform(post("/booking/book/152/1/A/")
+		mvc.perform(post("/booking/book/flights/152/rows/1/seats/A/")
 				.contentType(MediaType.APPLICATION_JSON).content("{\"id\": 1}"));
 		assertFalse(ticketDao.findByBookingId(bookingId).isEmpty());
-		mvc.perform(delete("/booking/book/" + bookingId))
+		mvc.perform(delete("/booking/book/bookings/" + bookingId))
 				.andExpect(status().isNoContent());
 		assertTrue(ticketDao.findByBookingId(bookingId).isEmpty());
-		mvc.perform(post("/booking/book/152/1/A/")
+		mvc.perform(post("/booking/book/flights/152/rows/1/seats/A/")
 				.contentType(MediaType.APPLICATION_JSON).content("{\"id\": 1}"));
-		mvc.perform(put("/booking/pay/" + bookingId)
+		mvc.perform(put("/booking/pay/bookings/" + bookingId)
 				.contentType(MediaType.APPLICATION_JSON).content("{\"price\":300}"));
-		mvc.perform(delete("/booking/book/" + bookingId))
+		mvc.perform(delete("/booking/book/bookings/" + bookingId))
 				.andExpect(status().isConflict());
 	}
 }

--- a/src/test/java/com/sst/utopia/booking/controller/BookingControllerTest.java
+++ b/src/test/java/com/sst/utopia/booking/controller/BookingControllerTest.java
@@ -1,6 +1,7 @@
 package com.sst.utopia.booking.controller;
 
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.time.LocalDateTime;
@@ -88,5 +89,20 @@ class BookingControllerTest {
 		mvc.perform(post("/booking/book/152/1/A/")
 				.contentType(MediaType.APPLICATION_JSON).content("{\"id\": 2}"))
 				.andExpect(status().isConflict());
+	}
+
+	@Test
+	public void testAcceptPayment() throws Exception {
+		mvc.perform(put("/booking/pay/152/1/A")
+				.contentType(MediaType.APPLICATION_JSON).content("{\"price\":300}"))
+				.andExpect(status().isGone());
+		mvc.perform(post("/booking/book/152/1/A/")
+				.contentType(MediaType.APPLICATION_JSON).content("{\"id\":1}"));
+		mvc.perform(put("/booking/pay/152/1/A")
+				.contentType(MediaType.APPLICATION_JSON).content("{\"price\":300}"))
+				.andExpect(status().isOk());
+		mvc.perform(put("/booking/pay/152/1/A")
+				.contentType(MediaType.APPLICATION_JSON).content("{\"price\":300}"))
+				.andExpect(status().isGone());
 	}
 }

--- a/src/test/java/com/sst/utopia/booking/controller/BookingControllerTest.java
+++ b/src/test/java/com/sst/utopia/booking/controller/BookingControllerTest.java
@@ -1,0 +1,92 @@
+package com.sst.utopia.booking.controller;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import java.time.LocalDateTime;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.junit4.SpringRunner;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.context.WebApplicationContext;
+
+import com.sst.utopia.booking.dao.AirportDao;
+import com.sst.utopia.booking.dao.FlightDao;
+import com.sst.utopia.booking.dao.TicketDao;
+import com.sst.utopia.booking.dao.UserDao;
+import com.sst.utopia.booking.model.Airport;
+import com.sst.utopia.booking.model.Flight;
+import com.sst.utopia.booking.model.SeatLocation;
+import com.sst.utopia.booking.model.Ticket;
+import com.sst.utopia.booking.model.User;
+
+/**
+ * Test of the booking controller.
+ * @author Jonathan Lovelace
+ */
+@RunWith(SpringRunner.class)
+@SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+class BookingControllerTest {
+	@Autowired
+    private WebApplicationContext context;
+
+	private MockMvc mvc;
+
+	/**
+	 * Airport DAO used in tests.
+	 */
+	@Autowired
+	private AirportDao airportDao;
+	/**
+	 * User DAO used in tests.
+	 */
+	@Autowired
+	private UserDao userDao;
+	/**
+	 * Flight DAO used in tests.
+	 */
+	@Autowired
+	private FlightDao flightDao;
+	/**
+	 * Ticket DAO used in tests.
+	 */
+	@Autowired
+	private TicketDao ticketDao;
+
+	/**
+	 * Set up sample data the booking service can operate on.
+	 */
+	@BeforeEach
+	public void init() {
+		mvc = MockMvcBuilders.webAppContextSetup(context).build();
+		airportDao.save(new Airport("QQQ", "Sample Airport One"));
+		airportDao.save(new Airport("QQX", "Sample Airport Two"));
+		userDao.save(new User(1, "sampleUser", "Sample User", "sample@example.com",
+				"5555555555"));
+		userDao.save(new User(2, "sampleUser2", "Second User", "second@example.com",
+				"5555555556"));
+		flightDao.save(new Flight(1, airportDao.findById("QQQ").get(),
+				LocalDateTime.now().plusDays(4), airportDao.findById("QQX").get(),
+				LocalDateTime.now().plusDays(6), 152));
+		ticketDao.save(new Ticket(
+				new SeatLocation(flightDao.findByFlightNumber(152).get(0), 1, "A"),
+				1));
+	}
+
+	@Test
+	public void testBookTicket() throws Exception {
+		mvc.perform(post("/booking/book/152/1/A/")
+				.contentType(MediaType.APPLICATION_JSON).content("{\"id\": 1}"))
+				.andExpect(status().isCreated());
+		mvc.perform(post("/booking/book/152/1/A/")
+				.contentType(MediaType.APPLICATION_JSON).content("{\"id\": 2}"))
+				.andExpect(status().isConflict());
+	}
+}

--- a/src/test/java/com/sst/utopia/booking/controller/BookingControllerTest.java
+++ b/src/test/java/com/sst/utopia/booking/controller/BookingControllerTest.java
@@ -103,6 +103,9 @@ class BookingControllerTest {
 				.andExpect(status().isOk());
 		mvc.perform(put("/booking/pay/152/1/A")
 				.contentType(MediaType.APPLICATION_JSON).content("{\"price\":300}"))
-				.andExpect(status().isGone());
+				.andExpect(status().isOk()); // testing idempotency
+		mvc.perform(put("/booking/pay/152/1/A")
+				.contentType(MediaType.APPLICATION_JSON).content("{\"price\":400}"))
+				.andExpect(status().isConflict());
 	}
 }

--- a/src/test/java/com/sst/utopia/booking/controller/BookingControllerTest.java
+++ b/src/test/java/com/sst/utopia/booking/controller/BookingControllerTest.java
@@ -1,6 +1,9 @@
 package com.sst.utopia.booking.controller;
 
 import static org.hamcrest.CoreMatchers.is;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
@@ -129,6 +132,42 @@ class BookingControllerTest {
 				.andExpect(status().isOk()); // testing idempotency
 		mvc.perform(put("/booking/pay/" + bookingId)
 				.contentType(MediaType.APPLICATION_JSON).content("{\"price\":400}"))
+				.andExpect(status().isConflict());
+	}
+
+	@Test
+	public void testCancelReservation() throws Exception {
+		final SeatLocation seat = new SeatLocation(flightDao.findByFlightNumber(152).get(0), 1, "A");
+		mvc.perform(delete("/booking/book/152/1/A")).andExpect(status().isNoContent());
+		mvc.perform(post("/booking/book/152/1/A/")
+				.contentType(MediaType.APPLICATION_JSON).content("{\"id\": 1}"));
+		assertTrue(ticketDao.findById(seat).map(Ticket::getReserver).isPresent());
+		mvc.perform(delete("/booking/book/152/1/A")).andExpect(status().isNoContent());
+		assertFalse(ticketDao.findById(seat).map(Ticket::getReserver).isPresent());
+		mvc.perform(delete("/booking/book/235/4/D")).andExpect(status().isNotFound());
+		mvc.perform(post("/booking/book/152/1/A/")
+				.contentType(MediaType.APPLICATION_JSON).content("{\"id\": 1}"));
+		mvc.perform(put("/booking/pay/152/1/A")
+				.contentType(MediaType.APPLICATION_JSON).content("{\"price\":300}"));
+		mvc.perform(delete("/booking/book/152/1/A")).andExpect(status().isConflict());
+	}
+
+	@Test
+	public void testCancelByBookingId() throws Exception {
+		final String bookingId = DigestUtils.md5DigestAsHex("152 1 A 1".getBytes());
+		mvc.perform(delete("/booking/book/" + bookingId))
+				.andExpect(status().isNoContent());
+		mvc.perform(post("/booking/book/152/1/A/")
+				.contentType(MediaType.APPLICATION_JSON).content("{\"id\": 1}"));
+		assertFalse(ticketDao.findByBookingId(bookingId).isEmpty());
+		mvc.perform(delete("/booking/book/" + bookingId))
+				.andExpect(status().isNoContent());
+		assertTrue(ticketDao.findByBookingId(bookingId).isEmpty());
+		mvc.perform(post("/booking/book/152/1/A/")
+				.contentType(MediaType.APPLICATION_JSON).content("{\"id\": 1}"));
+		mvc.perform(put("/booking/pay/" + bookingId)
+				.contentType(MediaType.APPLICATION_JSON).content("{\"price\":300}"));
+		mvc.perform(delete("/booking/book/" + bookingId))
 				.andExpect(status().isConflict());
 	}
 }

--- a/src/test/java/com/sst/utopia/booking/controller/BookingControllerTest.java
+++ b/src/test/java/com/sst/utopia/booking/controller/BookingControllerTest.java
@@ -170,4 +170,43 @@ class BookingControllerTest {
 		mvc.perform(delete("/booking/book/bookings/" + bookingId))
 				.andExpect(status().isConflict());
 	}
+
+	@Test
+	public void testExtendTimeout() throws Exception {
+		mvc.perform(put("/booking/extend/flights/152/rows/1/seats/A"))
+				.andExpect(status().isGone());
+		mvc.perform(post("/booking/book/flights/152/rows/1/seats/A/")
+				.contentType(MediaType.APPLICATION_JSON).content("{\"id\":1}"));
+		mvc.perform(put("/booking/extend/flights/152/rows/1/seats/A"))
+				.andExpect(status().isNoContent());
+		mvc.perform(delete("/booking/book/flights/152/rows/1/seats/A"));
+		mvc.perform(put("/booking/extend/flights/152/rows/1/seats/A"))
+				.andExpect(status().isGone());
+		mvc.perform(post("/booking/book/flights/152/rows/1/seats/A/")
+				.contentType(MediaType.APPLICATION_JSON).content("{\"id\":1}"));
+		mvc.perform(put("/booking/pay/flights/152/rows/1/seats/A")
+				.contentType(MediaType.APPLICATION_JSON).content("{\"price\":300}"));
+		mvc.perform(put("/booking/extend/flights/152/rows/1/seats/A"))
+				.andExpect(status().isConflict());
+	}
+
+	@Test
+	public void testExtendTimeoutByBookingId() throws Exception {
+		final String bookingId = DigestUtils.md5DigestAsHex("152 1 A 1".getBytes());
+		mvc.perform(put("/booking/extend/bookings/" + bookingId))
+				.andExpect(status().isGone());
+		mvc.perform(post("/booking/book/flights/152/rows/1/seats/A/")
+				.contentType(MediaType.APPLICATION_JSON).content("{\"id\":1}"));
+		mvc.perform(put("/booking/extend/bookings/" + bookingId))
+				.andExpect(status().isNoContent());
+		mvc.perform(delete("/booking/book/flights/152/rows/1/seats/A"));
+		mvc.perform(put("/booking/extend/bookings/" + bookingId))
+				.andExpect(status().isGone());
+		mvc.perform(post("/booking/book/flights/152/rows/1/seats/A/")
+				.contentType(MediaType.APPLICATION_JSON).content("{\"id\":1}"));
+		mvc.perform(put("/booking/pay/bookings/" + bookingId)
+				.contentType(MediaType.APPLICATION_JSON).content("{\"price\":300}"));
+		mvc.perform(put("/booking/extend/bookings/" + bookingId))
+				.andExpect(status().isConflict());
+	}
 }

--- a/src/test/java/com/sst/utopia/booking/controller/BookingControllerTest.java
+++ b/src/test/java/com/sst/utopia/booking/controller/BookingControllerTest.java
@@ -1,7 +1,9 @@
 package com.sst.utopia.booking.controller;
 
+import static org.hamcrest.CoreMatchers.is;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.put;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import java.time.LocalDateTime;
@@ -16,6 +18,7 @@ import org.springframework.http.MediaType;
 import org.springframework.test.context.junit4.SpringRunner;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.util.DigestUtils;
 import org.springframework.web.context.WebApplicationContext;
 
 import com.sst.utopia.booking.dao.AirportDao;
@@ -105,6 +108,26 @@ class BookingControllerTest {
 				.contentType(MediaType.APPLICATION_JSON).content("{\"price\":300}"))
 				.andExpect(status().isOk()); // testing idempotency
 		mvc.perform(put("/booking/pay/152/1/A")
+				.contentType(MediaType.APPLICATION_JSON).content("{\"price\":400}"))
+				.andExpect(status().isConflict());
+	}
+
+	@Test
+	public void testAcceptPaymentByBookingId() throws Exception {
+		final String bookingId = DigestUtils.md5DigestAsHex("152 1 A 1".getBytes());
+		mvc.perform(put("/booking/pay/" + bookingId)
+				.contentType(MediaType.APPLICATION_JSON).content("{\"price\":300}"))
+				.andExpect(status().isGone());
+		mvc.perform(post("/booking/book/152/1/A/")
+				.contentType(MediaType.APPLICATION_JSON).content("{\"id\":1}"))
+				.andExpect(jsonPath("$.bookingId", is(bookingId)));
+		mvc.perform(put("/booking/pay/" + bookingId)
+				.contentType(MediaType.APPLICATION_JSON).content("{\"price\":300}"))
+				.andExpect(status().isOk());
+		mvc.perform(put("/booking/pay/" + bookingId)
+				.contentType(MediaType.APPLICATION_JSON).content("{\"price\":300}"))
+				.andExpect(status().isOk()); // testing idempotency
+		mvc.perform(put("/booking/pay/" + bookingId)
 				.contentType(MediaType.APPLICATION_JSON).content("{\"price\":400}"))
 				.andExpect(status().isConflict());
 	}

--- a/src/test/resources/application.properties
+++ b/src/test/resources/application.properties
@@ -1,0 +1,3 @@
+utopia.expiration.minutes = 10
+logging.level.org.springframework=WARNING
+logging.level.root=WARNING


### PR DESCRIPTION
This code builds on #5 by adding a thin REST-controller layer on top of the service class. The only logic in these commits (other than the boilerplate needed to actually test the controller routes) should be translating inputs to model objects and exceptions to HTTP response codes.

(That's no longer quite true, as I've found I needed some changes to the model and service since the merging of #5.)