### PR TITLE
Fix database connection config

### DIFF
--- a/src/main/java/com/sst/utopia/booking/UtopiaBookingApplication.java
+++ b/src/main/java/com/sst/utopia/booking/UtopiaBookingApplication.java
@@ -2,7 +2,9 @@ package com.sst.utopia.booking;
 
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.PropertySource;
 
+@PropertySource("classpath:database-config.properties")
 @SpringBootApplication
 public class UtopiaBookingApplication {
 


### PR DESCRIPTION
This commit adds the necessary annotation to tell Spring to look for properties (such as the JDBC connection string) in `database-config.properties`.