### PR TITLE
Specify name of 'destination' join column explicitly in Flight.

### DIFF
--- a/src/main/java/com/sst/utopia/booking/model/Flight.java
+++ b/src/main/java/com/sst/utopia/booking/model/Flight.java
@@ -57,7 +57,7 @@ public class Flight implements Serializable {
 	 * The airport to which the flight will arrive.
 	 */
 	@ManyToOne
-	@JoinColumn
+	@JoinColumn(name="destination")
 	private Airport destination;
 	/**
 	 * The date and time the flight is scheduled to arrive.


### PR DESCRIPTION
Without this, JPA takes the name of the column to be 'destination_code', which of course 
does not exist, causing an exception that is transformed to an HTTP 500.