### PR TITLE
Don't include Ticket::isValid in its JSON representation.

### DIFF
--- a/src/main/java/com/sst/utopia/booking/model/Ticket.java
+++ b/src/main/java/com/sst/utopia/booking/model/Ticket.java
@@ -10,6 +10,7 @@ import javax.persistence.ManyToOne;
 import javax.persistence.Table;
 
 import com.fasterxml.jackson.annotation.JsonGetter;
+import com.fasterxml.jackson.annotation.JsonIgnore;
 import com.fasterxml.jackson.annotation.JsonProperty;
 import com.fasterxml.jackson.annotation.JsonProperty.Access;
 
@@ -198,6 +199,7 @@ public class Ticket {
 	/**
 	 * @return whether this object's state is internally consistent.
 	 */
+	@JsonIgnore
 	public boolean isValid() {
 		if (reserver == null) {
 			return reservationTimeout == null && price == null && bookingId == null;


### PR DESCRIPTION
The `isValid` method in the `Ticket` class isn't really a getter, but Jackson interprets it as one and so adds a corresponding field in the JSON. This *probably* doesn't do any *harm*, but it's slightly wasteful (about 14 bytes per response, plus the CPU required to add it in), could *possibly* confuse deserialization, and exposes some implementation details unnecessarily. So this commit tells Jackson to skip that method in JSON serialization.