### PR TITLE
Upgrade Spring to 2.1.6.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -6,7 +6,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>2.1.5.RELEASE</version>
+		<version>2.1.6.RELEASE</version>
 		<relativePath /> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>com.sst.utopia</groupId>


### PR DESCRIPTION
Version 2.1.5 pulls in a version of Jackson that has known security vulnerabilities.