### PR TITLE
Update Jackson dependency to a non-vulnerable version.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -18,7 +18,7 @@
 	<properties>
 		<java.version>1.8</java.version>
                 <junit-jupiter.version>5.4.2</junit-jupiter.version>
-		<jackson.version>2.9.9.1</jackson.version>
+		<jackson.version>2.9.9.20190727</jackson.version>
 	</properties>
 
 	<dependencies>

--- a/pom.xml
+++ b/pom.xml
@@ -18,6 +18,7 @@
 	<properties>
 		<java.version>1.8</java.version>
                 <junit-jupiter.version>5.4.2</junit-jupiter.version>
+		<jackson.version>2.9.9.1</jackson.version>
 	</properties>
 
 	<dependencies>


### PR DESCRIPTION
This won't compile at the moment, but should start compiling (and, I hope, work fine) once
FasterXML/jackson-bom#22 is merged.