### PR TITLE
Add BetterCodeHub configuration file to guide its analysis.

### DIFF
--- a/.bettercodehub.yml
+++ b/.bettercodehub.yml
@@ -1,0 +1,1 @@
+component_depth: 8


### PR DESCRIPTION
While investigating why BetterCodeHub was objecting to #13, I found (again) that it thought everything was in one architectural component, `src`. I decided to finally add the configuration file to correct this misapprehension. I *think* this is the syntax it wants for its config file.