### PR TITLE
Fix 500 on missing (or not-in-database) user ID

### DIFF
--- a/src/main/java/com/sst/utopia/booking/controller/BookingController.java
+++ b/src/main/java/com/sst/utopia/booking/controller/BookingController.java
@@ -3,6 +3,8 @@ package com.sst.utopia.booking.controller;
 import java.util.NoSuchElementException;
 
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.dao.DataIntegrityViolationException;
+import org.springframework.dao.InvalidDataAccessApiUsageException;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 import org.springframework.web.bind.annotation.DeleteMapping;
@@ -52,6 +54,10 @@ public class BookingController {
 					HttpStatus.CREATED);
 		} catch (final IllegalArgumentException except) {
 			return new ResponseEntity<>(HttpStatus.CONFLICT);
+		} catch (final DataIntegrityViolationException|InvalidDataAccessApiUsageException except) {
+			// FIXME: This might well also catch exceptions when flight/row/seat isn't in DB
+			// TODO: Should it be UNAUTHORIZED instead?
+			return new ResponseEntity<>(HttpStatus.FORBIDDEN);
 		} catch (final Exception except) {
 			return new ResponseEntity<>(HttpStatus.INTERNAL_SERVER_ERROR);
 		}


### PR DESCRIPTION
This four-line (plus comments) patch "fixes" the 500 error I was getting by catching the exception that is thrown when the `id` parameter in the `POST` body is missing (or, presumably, doesn't refer to a row in the users table). This is not nearly as robust as I would like (the service should check if the user is in the database and throw a custom exception if not; a nonexistent flight, row, or seat might also get matched by this `catch` block), but will have to do for now.