### PR TITLE
CI/CD scripts

### DIFF
--- a/cftemplate.json
+++ b/cftemplate.json
@@ -25,8 +25,8 @@
           "Fn::Base64": {
             "Fn::Join": [ "\n", [
               "#!/bin/bash",
-	      "yum update -y",
-              "yum install -y java-1.8.0-openjdk.x86_64",
+              "yum update -y",
+              "yum install -y java-1.8.0-openjdk-headless.x86_64",
               {"Fn::Join": [ " ", ["aws s3 cp", {"Ref": "JarFileSource"}, "."]]},
               {"Fn::Join": [ " ", ["nohup java -jar", {"Ref": "JarFileName"}, "&"]]}
             ]]

--- a/cftemplate.json
+++ b/cftemplate.json
@@ -3,7 +3,8 @@
   "Parameters": {
     "JarFileSource": {"Type": "String"},
     "JarFileName": {"Type": "String"},
-    "IAMRoleName": {"Type": "String"}
+    "IAMRoleName": {"Type": "String"},
+    "EC2KeyName": {"Type": "String"}
   },
   "Resources": {
     "EC2InstanceDemoSvr": {
@@ -33,7 +34,7 @@
         "IamInstanceProfile" : {"Ref": "IAMRoleName"},
         "ImageId": "ami-0c6b1d09930fac512",
         "InstanceType": "t2.micro",
-        "KeyName": "myKey",
+        "KeyName": {"Ref": "EC2KeyName"},
         "SecurityGroups":["launch-wizard-7"]
       }
     }

--- a/cftemplate.json
+++ b/cftemplate.json
@@ -25,7 +25,7 @@
           "Fn::Base64": {
             "Fn::Join": [ "\n", [
               "#!/bin/bash",
-              "yum install java-1.8.0-openjdk.x86_64",
+              "yum install -y java-1.8.0-openjdk.x86_64",
               {"Fn::Join": [ " ", ["aws s3 cp", {"Ref": "JarFileSource"}, "."]]},
               {"Fn::Join": [ " ", ["nohup java -jar", {"Ref": "JarFileName"}, "&"]]}
             ]]

--- a/cftemplate.json
+++ b/cftemplate.json
@@ -1,0 +1,52 @@
+{
+  "Description": "Create an EC2 instance by AWS CloudFormation",
+  "Parameters": {
+    "JarFileSource": {"Type": "String"},
+    "JarFileName": {"Type": "String"}
+  },
+  "Resources": {
+    "EC2InstanceDemoSvr": {
+      "Type": "AWS::EC2::Instance",
+      "Properties": {
+        "AvailabilityZone": "us-east-1a",
+        "BlockDeviceMappings": [
+          {
+            "DeviceName": "/dev/xvda",
+            "Ebs": {
+              "DeleteOnTermination": "true",
+              "VolumeSize": "8",
+              "VolumeType": "gp2"
+            }
+          }
+        ],
+        "UserData": {
+          "Fn::Base64": {
+            "Fn::Join": [ "\n", [
+              "#!/bin/bash",
+              "yum install java-1.8.0-openjdk.x86_64",
+              {"Fn::Join": [ " ", ["aws s3 cp", {"Ref": "JarFileSource"}, "."]]},
+              {"Fn::Join": [ " ", ["nohup java -jar", {"Ref": "JarFileName"}, "&"]]}
+            ]]
+          }
+        },
+        "IamInstanceProfile" : "S3role",
+        "ImageId": "ami-0c6b1d09930fac512",
+        "InstanceType": "t2.micro",
+        "KeyName": "myKey",
+        "SecurityGroups":["launch-wizard-7"]
+      }
+    }
+  },
+
+  "Outputs" : {
+    "Ec2EndPoint": {
+      "Value": {
+        "Fn::GetAtt": [
+          "EC2InstanceDemoSvr",
+          "PublicDnsName"
+        ]
+      },
+      "Description": "public DNS"
+    }
+  }
+}

--- a/cftemplate.json
+++ b/cftemplate.json
@@ -25,6 +25,7 @@
           "Fn::Base64": {
             "Fn::Join": [ "\n", [
               "#!/bin/bash",
+	      "yum update -y",
               "yum install -y java-1.8.0-openjdk.x86_64",
               {"Fn::Join": [ " ", ["aws s3 cp", {"Ref": "JarFileSource"}, "."]]},
               {"Fn::Join": [ " ", ["nohup java -jar", {"Ref": "JarFileName"}, "&"]]}

--- a/cftemplate.json
+++ b/cftemplate.json
@@ -2,7 +2,8 @@
   "Description": "Create an EC2 instance by AWS CloudFormation",
   "Parameters": {
     "JarFileSource": {"Type": "String"},
-    "JarFileName": {"Type": "String"}
+    "JarFileName": {"Type": "String"},
+    "IAMRoleName": {"Type": "String"}
   },
   "Resources": {
     "EC2InstanceDemoSvr": {
@@ -29,7 +30,7 @@
             ]]
           }
         },
-        "IamInstanceProfile" : "S3role",
+        "IamInstanceProfile" : {"Ref": "IAMRoleName"},
         "ImageId": "ami-0c6b1d09930fac512",
         "InstanceType": "t2.micro",
         "KeyName": "myKey",

--- a/jenkins-cd.groovy
+++ b/jenkins-cd.groovy
@@ -1,5 +1,8 @@
 properties([parameters([string(defaultValue: 'booking-0.0.1-SNAPSHOT.jar', description: 'Name of the artifact to be deployed', name: 'ArtifactName', trim: true), string(defaultValue: 'us-east-1', description: 'AWS region to deploy the stack in', name: 'AWSRegion', trim: true), string(defaultValue: '', description: 'Name to give the stack', name: 'StackName'), string(defaultValue: '', description: 'The S3 bucket the artifact should be taken from and endpoint URL placed in', name: 'TargetBucket', trim: false)])]);
 node {
+    stage("Source"){
+        git branch: 'elk-monitoring', url: 'https://github.com/kingjon3377/UtopiaBookingService.git';
+    }
     stage('Delete previous cloud formation stack') {
         sh label: 'Delete old cloud formation', script: 'aws --region us-east-1 cloudformation delete-stack --stack-name booking-service-auto-gen'
         sh label: 'Wait for the deletion of cloud formation', script: 'aws --region us-east-1 cloudformation wait stack-delete-complete --stack-name booking-service-auto-gen || true'

--- a/jenkins-cd.groovy
+++ b/jenkins-cd.groovy
@@ -1,4 +1,4 @@
-properties([parameters([string(defaultValue: 'booking-0.0.1-SNAPSHOT.jar', description: 'Name of the artifact to be deployed', name: 'ArtifactName', trim: true), string(defaultValue: 'us-east-1', description: 'AWS region to deploy the stack in', name: 'AWSRegion', trim: true), string(defaultValue: '', description: 'Name to give the stack', name: 'StackName'), string(defaultValue: '', description: 'The S3 bucket the artifact should be taken from and endpoint URL placed in', name: 'TargetBucket', trim: false)])]);
+properties([parameters([string(defaultValue: 'booking-0.0.1-SNAPSHOT.jar', description: 'Name of the artifact to be deployed', name: 'ArtifactName', trim: true), string(defaultValue: 'us-east-1', description: 'AWS region to deploy the stack in', name: 'AWSRegion', trim: true), string(defaultValue: 'booking-service-stack', description: 'Name to give the stack', name: 'StackName')])]);
 node {
     stage("Source"){
         git branch: 'elk-monitoring', url: 'https://github.com/kingjon3377/UtopiaBookingService.git';
@@ -10,22 +10,26 @@ node {
 
     stage('Create parameters file') {
         sh label: 'Remove old parameters file', script: 'rm -f cloud-formation-params.json';
-        writeFile encoding: 'UTF-8', file: 'cloud-formation-params.json', text: """[
+        withCredentials([string(credentialsId: 'TargetBucket', variable: 'TargetBucket')]) {
+            writeFile encoding: 'UTF-8', file: 'cloud-formation-params.json', text: """[
   {
     "ParameterKey": "JarFileSource",
-    "ParameterValue": "s3://${params.TargetBucket}/${params.ArtifactName}"
+    "ParameterValue": "s3://${TargetBucket}/${params.ArtifactName}"
   },
   {
     "ParamaterKey": "JarFileName",
     "ParameterValue": "${params.ArtifactName}"
   }
 ]"""
+        }
     }
 
     stage('Create cloud-formation stack') {
         sh label: 'Create new Cloud Stack', script: "aws --region ${params.AWSRegion} cloudformation create-stack --stack-name ${params.StackName} --template-body file://cftemplate.json --parameters file://cloud-formation-params.json";
         sh label: 'Wait for the creation of the cloud formation', script: "aws --region ${params.AWSRegion} cloudformation wait stack-create-complete --stack-name ${params.StackName}";
         sh label: 'Get endpoint DNS', script: 'aws cloudformation describe-stacks --stack-name EC2stack | jq \'.Stacks | .[0] | .Outputs | .[] | .OutputValue\' | sed \'s@^"\\(.*\\)"@\\1@\' | tac | tr \'\\n\' : | sed \'s@:$@@\' > BookingHost.url';
-        s3Upload bucket: "${params.TargetBucket}", file: 'BookingHost.url';
+        withCredentials([string(credentialsId: 'TargetBucket', variable: 'TargetBucket')]) {
+            s3Upload bucket: "${TargetBucket}", file: 'BookingHost.url';
+        }
     }
 }

--- a/jenkins-cd.groovy
+++ b/jenkins-cd.groovy
@@ -10,7 +10,7 @@ node {
 
     stage('Create parameters file') {
         sh label: 'Remove old parameters file', script: 'rm -f cloud-formation-params.json';
-        withCredentials([string(credentialsId: 'TargetBucket', variable: 'TargetBucket')]) {
+        withCredentials([string(credentialsId: 'TargetBucket', variable: 'TargetBucket'), string(credentialsId: 'IAMRole', variable: 'IAMRole')]) {
             writeFile encoding: 'UTF-8', file: 'cloud-formation-params.json', text: """[
   {
     "ParameterKey": "JarFileSource",
@@ -19,6 +19,10 @@ node {
   {
     "ParameterKey": "JarFileName",
     "ParameterValue": "${params.ArtifactName}"
+  },
+  {
+    "ParameterKey": "IAMRoleName",
+    "ParameterValue": "${IAMRole}"
   }
 ]"""
         }

--- a/jenkins-cd.groovy
+++ b/jenkins-cd.groovy
@@ -10,7 +10,7 @@ node {
 
     stage('Create parameters file') {
         sh label: 'Remove old parameters file', script: 'rm -f cloud-formation-params.json';
-        withCredentials([string(credentialsId: 'TargetBucket', variable: 'TargetBucket'), string(credentialsId: 'IAMRole', variable: 'IAMRole')]) {
+        withCredentials([string(credentialsId: 'TargetBucket', variable: 'TargetBucket'), string(credentialsId: 'IAMRole', variable: 'IAMRole'), string(credentialsId: 'EC2Key', variable: 'EC2Key')]) {
             writeFile encoding: 'UTF-8', file: 'cloud-formation-params.json', text: """[
   {
     "ParameterKey": "JarFileSource",
@@ -23,6 +23,10 @@ node {
   {
     "ParameterKey": "IAMRoleName",
     "ParameterValue": "${IAMRole}"
+  },
+  {
+    "ParameterKey": "EC2KeyName",
+    "ParameterValue": "${EC2Key}"
   }
 ]"""
         }

--- a/jenkins-cd.groovy
+++ b/jenkins-cd.groovy
@@ -10,7 +10,16 @@ node {
 
     stage('Create parameters file') {
         sh label: 'Remove old parameters file', script: 'rm -f cloud-formation-params.json';
-        sh label: 'Create parameters file', script: "printf '[{%s},\n{%s}]\n' '{\"ParameterKey\": \"JarFileSource\",\"ParameterValue\": \"s3://${params.TargetBucket}/${params.ArtifactName}\"}' '{\"ParameterKey\": \"JarFileName\",\"ParameterValue\": \"${params.ArtifactName}\"}' > cloud-formation-params.json"
+        writeFile encoding: 'UTF-8', file: 'cloud-formation-params.json', text: """[
+  {
+    "ParameterKey": "JarFileSource",
+    "ParameterValue": "s3://${params.TargetBucket}/${params.ArtifactName}"
+  },
+  {
+    "ParamaterKey": "JarFileName",
+    "ParameterValue": "${params.ArtifactName}"
+  }
+]"""
     }
 
     stage('Create cloud-formation stack') {

--- a/jenkins-cd.groovy
+++ b/jenkins-cd.groovy
@@ -17,7 +17,7 @@ node {
     "ParameterValue": "s3://${TargetBucket}/${params.ArtifactName}"
   },
   {
-    "ParamaterKey": "JarFileName",
+    "ParameterKey": "JarFileName",
     "ParameterValue": "${params.ArtifactName}"
   }
 ]"""

--- a/jenkins-cd.groovy
+++ b/jenkins-cd.groovy
@@ -4,8 +4,8 @@ node {
         git branch: 'elk-monitoring', url: 'https://github.com/kingjon3377/UtopiaBookingService.git';
     }
     stage('Delete previous cloud formation stack') {
-        sh label: 'Delete old cloud formation', script: 'aws --region us-east-1 cloudformation delete-stack --stack-name booking-service-auto-gen'
-        sh label: 'Wait for the deletion of cloud formation', script: 'aws --region us-east-1 cloudformation wait stack-delete-complete --stack-name booking-service-auto-gen || true'
+        sh label: 'Delete old cloud formation', script: "aws --region us-east-1 cloudformation delete-stack --stack-name ${params.StackName}"
+        sh label: 'Wait for the deletion of cloud formation', script: "aws --region us-east-1 cloudformation wait stack-delete-complete --stack-name ${params.StackName} || true"
     }
 
     stage('Create parameters file') {

--- a/jenkins-cd.groovy
+++ b/jenkins-cd.groovy
@@ -1,0 +1,19 @@
+properties([parameters([string(defaultValue: 'booking-0.0.1-SNAPSHOT.jar', description: 'Name of the artifact to be deployed', name: 'ArtifactName', trim: true), string(defaultValue: 'us-east-1', description: 'AWS region to deploy the stack in', name: 'AWSRegion', trim: true), string(defaultValue: '', description: 'Name to give the stack', name: 'StackName'), string(defaultValue: '', description: 'The S3 bucket the artifact should be taken from and endpoint URL placed in', name: 'TargetBucket', trim: false)])]);
+node {
+    stage('Delete previous cloud formation stack') {
+        sh label: 'Delete old cloud formation', script: 'aws --region us-east-1 cloudformation delete-stack --stack-name booking-service-auto-gen'
+        sh label: 'Wait for the deletion of cloud formation', script: 'aws --region us-east-1 cloudformation wait stack-delete-complete --stack-name booking-service-auto-gen || true'
+    }
+
+    stage('Create parameters file') {
+        sh label: 'Remove old parameters file', script: 'rm -f cloud-formation-params.json';
+        sh label: 'Create parameters file', script: "printf '[{%s},\n{%s}]\n' '{\"ParameterKey\": \"JarFileSource\",\"ParameterValue\": \"s3://${params.TargetBucket}/${params.ArtifactName}\"}' '{\"ParameterKey\": \"JarFileName\",\"ParameterValue\": \"${params.ArtifactName}\"}' > cloud-formation-params.json"
+    }
+
+    stage('Create cloud-formation stack') {
+        sh label: 'Create new Cloud Stack', script: "aws --region ${params.AWSRegion} cloudformation create-stack --stack-name ${params.StackName} --template-body file://cftemplate.json --parameters file://cloud-formation-params.json";
+        sh label: 'Wait for the creation of the cloud formation', script: "aws --region ${params.AWSRegion} cloudformation wait stack-create-complete --stack-name ${params.StackName}";
+        sh label: 'Get endpoint DNS', script: 'aws cloudformation describe-stacks --stack-name EC2stack | jq \'.Stacks | .[0] | .Outputs | .[] | .OutputValue\' | sed \'s@^"\\(.*\\)"@\\1@\' | tac | tr \'\\n\' : | sed \'s@:$@@\' > BookingHost.url';
+        s3Upload bucket: "${params.TargetBucket}", file: 'BookingHost.url';
+    }
+}

--- a/jenkins-ci.groovy
+++ b/jenkins-ci.groovy
@@ -17,7 +17,7 @@ spring.datasource.username=${RDSUser}
 spring.datasource.password=${RDSPassword}""";
         }
     }
-   
+
     stage("build") {
         sh 'mvn clean package';
     }

--- a/jenkins-ci.groovy
+++ b/jenkins-ci.groovy
@@ -3,10 +3,10 @@ node {
         git branch: 'elk-monitoring', url: 'https://github.com/kingjon3377/UtopiaBookingService.git';
     }
     stage('Add application.properties') {
-        sh label: 'Remove old application.properties', script: 'rm -f src/main/resources/application.properties';
+        sh label: 'Remove old properties file', script: 'rm -f src/main/resources/database-config.properties';
 
         withCredentials([string(credentialsId: 'RDSURL', variable: 'RDSURL'), usernamePassword(credentialsId: 'RDSCredentials', passwordVariable: 'RDSPassword', usernameVariable: 'RDSUser')]) {
-            writeFile encoding: 'UTF-8', file: 'src/main/resources/application.properties', text: """spring.datasource.driverClassName=com.mysql.cj.jdbc.Driver
+            writeFile encoding: 'UTF-8', file: 'src/main/resources/database-config.properties', text: """spring.datasource.driverClassName=com.mysql.cj.jdbc.Driver
 spring.mvc.throw-exception-if-no-handler-found=true
 spring.resources.add-mappings=false
 spring.jpa.hibernate.ddl-auto = update

--- a/jenkins-ci.groovy
+++ b/jenkins-ci.groovy
@@ -1,0 +1,26 @@
+properties([parameters([string(defaultValue: '', description: 'URL for database to connect instances to. ', name: 'RDSURL', trim: false), string(defaultValue: 'root', description: 'Username for connecting to the database.', name: 'RDSUser', trim: false), password(defaultValue: '', description: 'Password for connecting to the database', name: 'RDSPassword'), string(defaultValue: '', description: 'The S3 bucket the artifact(s) should be placed in', name: 'TargetBucket', trim: false)])]);
+node {
+    stage("Source"){
+        git branch: 'elk-monitoring', url: 'https://github.com/kingjon3377/UtopiaBookingService.git';
+    }
+    stage('Add application.properties') {
+        sh label: 'Remove old application.properties', script: 'rm -f src/main/resources/application.properties';
+
+        writeFile encoding: 'UTF-8', file: 'src/main/resources/application.properties', text: '''spring.datasource.driverClassName=com.mysql.cj.jdbc.Driver
+spring.mvc.throw-exception-if-no-handler-found=true
+spring.resources.add-mappings=false
+spring.jpa.hibernate.ddl-auto = update
+spring.jpa.hibernate.naming.implicit-strategy=org.hibernate.boot.model.naming.ImplicitNamingStrategyLegacyJpaImpl
+spring.jpa.hibernate.naming.physical-strategy=org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl''';
+        sh label: 'Add sensitive details to application.properties', script: "printf \'\n%s\n%s\n%s\n\' \'spring.datasource.url=jdbc:mysql://${params.RDSURL}\' \'spring.datasource.username=${params.RDSUser}\' \'spring.datasource.password=${params.RDSPassword}\' >> src/main/resources/application.properties"
+    }
+   
+    stage("build") {
+        sh 'mvn clean package';
+    }
+
+    stage("archive") {
+        archiveArtifacts 'target/*.jar';
+        s3Upload bucket: "${params.TargetBucket}", includePathPattern: 'target/*.jar';
+    }
+}

--- a/jenkins-ci.groovy
+++ b/jenkins-ci.groovy
@@ -25,7 +25,9 @@ spring.datasource.password=${RDSPassword}""";
     stage("archive") {
         archiveArtifacts 'target/*.jar';
         withCredentials([string(credentialsId: 'TargetBucket', variable: 'TargetBucket')]) {
-            s3Upload bucket: "${TargetBucket}", includePathPattern: 'target/*.jar';
+            dir("target") {
+                s3Upload bucket: "${TargetBucket}", includePathPattern: '*.jar';
+            }
         }
     }
 }

--- a/jenkins-ci.groovy
+++ b/jenkins-ci.groovy
@@ -6,13 +6,15 @@ node {
     stage('Add application.properties') {
         sh label: 'Remove old application.properties', script: 'rm -f src/main/resources/application.properties';
 
-        writeFile encoding: 'UTF-8', file: 'src/main/resources/application.properties', text: '''spring.datasource.driverClassName=com.mysql.cj.jdbc.Driver
+        writeFile encoding: 'UTF-8', file: 'src/main/resources/application.properties', text: """spring.datasource.driverClassName=com.mysql.cj.jdbc.Driver
 spring.mvc.throw-exception-if-no-handler-found=true
 spring.resources.add-mappings=false
 spring.jpa.hibernate.ddl-auto = update
 spring.jpa.hibernate.naming.implicit-strategy=org.hibernate.boot.model.naming.ImplicitNamingStrategyLegacyJpaImpl
-spring.jpa.hibernate.naming.physical-strategy=org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl''';
-        sh label: 'Add sensitive details to application.properties', script: "printf \'\n%s\n%s\n%s\n\' \'spring.datasource.url=jdbc:mysql://${params.RDSURL}\' \'spring.datasource.username=${params.RDSUser}\' \'spring.datasource.password=${params.RDSPassword}\' >> src/main/resources/application.properties"
+spring.jpa.hibernate.naming.physical-strategy=org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
+spring.datasource.url=jdbc:mysql://${params.RDSURL}
+spring.datasource.username=${params.RDSUser}
+spring.datasource.password=${params.RDSPassword}""";
     }
    
     stage("build") {

--- a/jenkins-ci.groovy
+++ b/jenkins-ci.groovy
@@ -1,4 +1,3 @@
-properties([parameters([string(defaultValue: '', description: 'URL for database to connect instances to. ', name: 'RDSURL', trim: false), string(defaultValue: 'root', description: 'Username for connecting to the database.', name: 'RDSUser', trim: false), password(defaultValue: '', description: 'Password for connecting to the database', name: 'RDSPassword'), string(defaultValue: '', description: 'The S3 bucket the artifact(s) should be placed in', name: 'TargetBucket', trim: false)])]);
 node {
     stage("Source"){
         git branch: 'elk-monitoring', url: 'https://github.com/kingjon3377/UtopiaBookingService.git';
@@ -6,15 +5,17 @@ node {
     stage('Add application.properties') {
         sh label: 'Remove old application.properties', script: 'rm -f src/main/resources/application.properties';
 
-        writeFile encoding: 'UTF-8', file: 'src/main/resources/application.properties', text: """spring.datasource.driverClassName=com.mysql.cj.jdbc.Driver
+        withCredentials([string(credentialsId: 'RDSURL', variable: 'RDSURL'), usernamePassword(credentialsId: 'RDSCredentials', passwordVariable: 'RDSPassword', usernameVariable: 'RDSUser')]) {
+            writeFile encoding: 'UTF-8', file: 'src/main/resources/application.properties', text: """spring.datasource.driverClassName=com.mysql.cj.jdbc.Driver
 spring.mvc.throw-exception-if-no-handler-found=true
 spring.resources.add-mappings=false
 spring.jpa.hibernate.ddl-auto = update
 spring.jpa.hibernate.naming.implicit-strategy=org.hibernate.boot.model.naming.ImplicitNamingStrategyLegacyJpaImpl
 spring.jpa.hibernate.naming.physical-strategy=org.hibernate.boot.model.naming.PhysicalNamingStrategyStandardImpl
-spring.datasource.url=jdbc:mysql://${params.RDSURL}
-spring.datasource.username=${params.RDSUser}
-spring.datasource.password=${params.RDSPassword}""";
+spring.datasource.url=jdbc:mysql://${RDSURL}
+spring.datasource.username=${RDSUser}
+spring.datasource.password=${RDSPassword}""";
+        }
     }
    
     stage("build") {
@@ -23,6 +24,8 @@ spring.datasource.password=${params.RDSPassword}""";
 
     stage("archive") {
         archiveArtifacts 'target/*.jar';
-        s3Upload bucket: "${params.TargetBucket}", includePathPattern: 'target/*.jar';
+        withCredentials([string(credentialsId: 'TargetBucket', variable: 'TargetBucket')]) {
+            s3Upload bucket: "${TargetBucket}", includePathPattern: 'target/*.jar';
+        }
     }
 }


### PR DESCRIPTION
The CI/CD scripts that built and deployed the code in this repository have so far not been stored in this repository, and have thus not undergone code review. When I tried to get them to work with instances in my account, for my ElasticSearch experiments, I found I had to make a number of changes. Thus this PR, which puts the Jenkins CI and CD scripts and the CloudFormation template under version control (Jenkins just has to be configured to run a Pipelines script from the Git checkout under the nonstandard name we use, and to have the necessary parameters stored in the credential store) and includes such improvements to those scripts as I found it necessary or desirable to make.

The one real problem I still see with these is that credentials are getting embedded into the JAR file rather than being placed alongside it in the EC2 instance(s), or even better being loaded from some credentials vault at runtime.

If there are any issues, please let me know so I can fix them; I'd like this to be a model for the other services' CI and CD processes.